### PR TITLE
create stairs for block, not ingot

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -450,7 +450,7 @@ minetest.register_node("lavastuff:block", {
 })
 
 if minetest.get_modpath("moreblocks") then
-	stairsplus:register_all("lavastuff", "lava", "lavastuff:ingot", {
+	stairsplus:register_all("lavastuff", "lava", "lavastuff:block", {
 		description = "Lava",
 		tiles = {"lavastuff_block.png"},
 		groups = {cracky = 2, level = 2},


### PR DESCRIPTION
this was clearly a bug, but is now required for compatibility with https://github.com/minetest-mods/moreblocks/pull/191